### PR TITLE
Fix ExtensionError super() call

### DIFF
--- a/modules/emulator/src/exceptions/exceptions.py
+++ b/modules/emulator/src/exceptions/exceptions.py
@@ -1,4 +1,3 @@
 class ExtensionError(Exception):
     def __init__(self, message):
-        super(ExtensionError).__init__(message)
-
+        super().__init__(message)


### PR DESCRIPTION
Fixed a bug in ExtensionError where super(ExtensionError).__init__(message) 
was called without an instance, causing a TypeError instead of raising the 
intended error. Changed it to super().__init__(message).