### PR TITLE
Implement subsequent execution in MeasurementsClient

### DIFF
--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -111,7 +111,7 @@ def measure_country(country):
                 tr_results = json.loads(tr_ripe.stdout)
                 if tr_results and isinstance(tr_results, list):
                     
-                    hop_count = len(tr_results[0].get('result', []))
+                    hop_count = len(tr_results[0].get('result') or [])
             except Exception as tr_e:
                 logging.error(f"Error performing traceroute for probe {probe_id} in {country}: {tr_e}")
 

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -15,7 +15,7 @@ data_lock = threading.Lock()
 with open('config.json', 'r') as f:
     config = json.load(f)
 
-#Get the constants for the RIPE Atlas Measurements from config.json.
+
 target = config['Target']
 no_of_probes = config['NoOfProbes']
 from_countries = config['From']
@@ -24,7 +24,7 @@ packets = config['Packets']
 me = config['Me']
 size = config['Size']
 
-# Global Constants: Configurations and folder locations
+
 EXTRACTION_RUNNING = False
 TRIMMED_LOGS = False
 INIT_EXECUTION = True
@@ -37,18 +37,18 @@ iteration = 0
 if not os.path.exists('output'):
     os.makedirs('output')
 
-# Output in a preferred format.
+
 if TRIMMED_LOGS:
     logging.basicConfig(filename='output/awanta.out', level=logging.INFO, format='%(message)s')
 else:
 	logging.basicConfig(filename='output/awanta.out', level=logging.INFO, format='%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
 
-# A dictionary of dictionaries, to store the output of measurements: [country:[src: rtt]]
+
 whole_dict = dict()
 completed_countries = list()            
 
 
-# All measured endpoints are saved between iterations as JSON files.
+
 try:
     with open(latency_file, 'r') as f:
         whole_dict = json.load(f)
@@ -64,6 +64,65 @@ except (FileNotFoundError, json.JSONDecodeError):
 
 event_manager = EventManager()
 
+
+def measure_country(country):
+    """
+    Run a ping measurement (for RTT/jitter) and a traceroute measurement
+    (for hop count) against `target`, from probes in the given country.
+    Returns a dict of {probe_id: {"rtt": ..., "jitter": ..., "hop_count": ...}}.
+    """
+    logging.info('Measuring for country: ' + country)
+    each_dict = dict()
+    
+    cmd = [
+        "ripe-atlas", "measure", str(measure),
+        "--target", str(target),
+        "--probes", str(no_of_probes),
+        "--from-country", str(country),
+        "--packets", str(packets),
+        "--size", str(size),
+        "--renderer", "json"
+    ]
+    ripe = subprocess.run(cmd, capture_output=True, shell=False, encoding="utf8")
+
+    try:
+        results = json.loads(ripe.stdout)
+        for res in results:
+            probe_id = str(res.get('prb_id'))
+            rtts = [r.get('rtt') for r in res.get('result', []) if r.get('rtt') is not None]
+
+            avg_rtt = 0.0
+            jitter = 0.0
+            if rtts:
+                avg_rtt = sum(rtts) / len(rtts)
+                
+                variance = sum((x - avg_rtt) ** 2 for x in rtts) / len(rtts)
+                jitter = variance ** 0.5
+
+            
+            hop_count = 0
+            try:
+                tr_cmd = [
+                    "ripe-atlas", "measure", "traceroute",
+                    "--target", str(target),
+                    "--probes", str(probe_id),
+                    "--renderer", "json"
+                ]
+                tr_ripe = subprocess.run(tr_cmd, capture_output=True, shell=False, encoding="utf8")
+                tr_results = json.loads(tr_ripe.stdout)
+                if tr_results and isinstance(tr_results, list):
+                    
+                    hop_count = len(tr_results[0].get('result', []))
+            except Exception as tr_e:
+                logging.error(f"Error performing traceroute for probe {probe_id} in {country}: {tr_e}")
+
+            each_dict[probe_id] = {"rtt": avg_rtt, "jitter": jitter, "hop_count": hop_count}
+    except Exception as e:
+        logging.error(f"Error parsing RIPE Atlas output for {country}: {e}")
+
+    return each_dict
+
+
 def measure_latency():
     global whole_dict
     global EXTRACTION_RUNNING
@@ -76,85 +135,48 @@ def measure_latency():
     else:
         t_start = time.time()
         EXTRACTION_RUNNING = True
-    
-        if INIT_EXECUTION:
-            # Loop through each country in the array of countries.
-            for country in from_countries:
-                logging.info('Measuring for country: ' + country)
-                each_dict = dict()
-                # Using --renderer json for precise data extraction and jitter calculation
-                cmd = [
-                    "ripe-atlas", "measure", str(measure),
-                    "--target", str(target),
-                    "--probes", str(no_of_probes),
-                    "--from-country", str(country),
-                    "--packets", str(packets),
-                    "--size", str(size),
-                    "--renderer", "json"
-                ]
-                ripe = subprocess.run(cmd, capture_output=True, shell=False, encoding="utf8")
-                
-                try:
-                    results = json.loads(ripe.stdout)
-                    for res in results:
-                        probe_id = str(res.get('prb_id'))
-                        rtts = [r.get('rtt') for r in res.get('result', []) if r.get('rtt') is not None]
-                        
-                        avg_rtt = 0.0
-                        jitter = 0.0
-                        if rtts:
-                            avg_rtt = sum(rtts) / len(rtts)
-                            # Jitter as Standard Deviation
-                            variance = sum((x - avg_rtt) ** 2 for x in rtts) / len(rtts)
-                            jitter = variance ** 0.5
-                        
-                        # Traceroute for hop count analysis
-                        hop_count = 0
-                        try:
-                            tr_cmd = [
-                                "ripe-atlas", "measure", "traceroute",
-                                "--target", str(target),
-                                "--probes", str(probe_id),
-                                "--renderer", "json"
-                            ]
-                            tr_ripe = subprocess.run(tr_cmd, capture_output=True, shell=False, encoding="utf8")
-                            tr_results = json.loads(tr_ripe.stdout)
-                            if tr_results and isinstance(tr_results, list):
-                                # The number of elements in the 'result' array represents the hops
-                                hop_count = len(tr_results[0].get('result', []))
-                        except Exception as tr_e:
-                            logging.error(f"Error performing traceroute for probe {probe_id} in {country}: {tr_e}")
 
-                        each_dict[probe_id] = {"rtt": avg_rtt, "jitter": jitter, "hop_count": hop_count}
-                except Exception as e:
-                    logging.error(f"Error parsing RIPE Atlas output for {country}: {e}")
-                
+        if INIT_EXECUTION:
+            
+            for country in from_countries:
+                each_dict = measure_country(country)
+
                 with data_lock:
                     whole_dict[country] = each_dict
                     completed_countries.append(country)
-                # Publish event via Event Manager for real-time propagation
+                
                 event_manager.publish_measurement({"country": country, "data": each_dict})
+
             
-            # Write in a human readable file after all countries have been processed.
             with open(current_measurement_file, 'w') as f:
                 json.dump(whole_dict, f)
-            
+
             INIT_EXECUTION = False
 
         else:
-            # Update the whole_dict incrementally. But not a complete rerun.
-            logging.info("Todo: Subsequent Execution is not implemented yet...")
+            
+            for country in list(completed_countries):
+                each_dict = measure_country(country)
+
+                with data_lock:
+                    whole_dict[country] = each_dict
+                
+                event_manager.publish_measurement({"country": country, "data": each_dict})
+
+            
+            with open(current_measurement_file, 'w') as f:
+                json.dump(whole_dict, f)
 
         iteration += 1
-        # Record the total run-time
+        
         logging.info('Total run time: %s %s', (time.time() - t_start)/60, ' minutes!')
         EXTRACTION_RUNNING = False
 
-        # Print the dictionary to a local file.
+        
         logging.info(whole_dict)
 
 
-# Write the JSON file periodically to track the progress and persist it to the filesystem
+
 def update_json():
     global whole_dict
     global completed_countries
@@ -168,12 +190,18 @@ def update_json():
 def run_threaded(job_func):
     job_thread = threading.Thread(target=job_func)
     job_thread.start()
-    
-# The thread scheduling
-schedule.every(1).minutes.do(run_threaded, measure_latency)
-schedule.every(2).minutes.do(run_threaded, update_json)
 
-# Keep running in a loop.
-while True:
-    schedule.run_pending()
-    time.sleep(1)
+
+def main():
+    
+    schedule.every(1).minutes.do(run_threaded, measure_latency)
+    schedule.every(2).minutes.do(run_threaded, update_json)
+
+    
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -88,7 +88,7 @@ def measure_country(country):
         results = json.loads(ripe.stdout)
         for res in results:
             probe_id = str(res.get('prb_id'))
-            rtts = [r.get('rtt') for r in res.get('result', []) if r.get('rtt') is not None]
+            rtts = [r.get('rtt') for r in (res.get('result') or []) if r.get('rtt') is not None]
 
             avg_rtt = 0.0
             jitter = 0.0

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -15,7 +15,7 @@ data_lock = threading.Lock()
 with open('config.json', 'r') as f:
     config = json.load(f)
 
-
+#Get the constants for the RIPE Atlas Measurements from config.json.
 target = config['Target']
 no_of_probes = config['NoOfProbes']
 from_countries = config['From']

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -83,9 +83,8 @@ def measure_country(country):
         "--size", str(size),
         "--renderer", "json"
     ]
-    ripe = subprocess.run(cmd, capture_output=True, shell=False, encoding="utf8")
-
     try:
+        ripe = subprocess.run(cmd, capture_output=True, shell=False, encoding="utf8")
         results = json.loads(ripe.stdout)
         for res in results:
             probe_id = str(res.get('prb_id'))


### PR DESCRIPTION
MeasurementsClient previously only performed a single full measurement pass across 
all configured countries on startup. Any run after the first one hit an unimplemented 
branch that just logged a TODO message and did nothing, so latency data was never 
refreshed after the initial measurement.

This PR implements that missing subsequent execution path. The per-country ping and 
traceroute measurement logic has been extracted into a separate measure_country 
function so it can be reused instead of duplicated. On later scheduled runs, the 
client now re-measures each country that was already completed in a prior pass and 
updates whole_dict with the new values, publishing an event for each update the same 
way the initial run does.

As a smaller supporting change, the module-level scheduling loop that previously ran 
immediately on import has been moved into a main() function guarded by 
if __name__ == "__main__". This keeps the script's behavior identical when run 
directly, while making the file safely importable for testing purposes.