### PR TITLE
Add config validation to MeasurementsClient's config.json loading

### DIFF
--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -56,13 +56,16 @@ def validate_config(config):
         elif not all(isinstance(c, str) and len(c) == 2 for c in config["From"]):
             errors.append("'From' must be a list of 2-letter country codes (e.g. 'US', 'IN')")
 
-    if isinstance(config.get("NoOfProbes"), int) and config["NoOfProbes"] <= 0:
+    no_of_probes = config.get("NoOfProbes")
+    if isinstance(no_of_probes, int) and not isinstance(no_of_probes, bool) and no_of_probes <= 0:
         errors.append("'NoOfProbes' must be a positive integer")
 
-    if isinstance(config.get("Packets"), int) and config["Packets"] <= 0:
+    packets = config.get("Packets")
+    if isinstance(packets, int) and not isinstance(packets, bool) and packets <= 0:
         errors.append("'Packets' must be a positive integer")
 
-    if isinstance(config.get("Size"), int) and config["Size"] <= 0:
+    size = config.get("Size")
+    if isinstance(size, int) and not isinstance(size, bool) and size <= 0:
         errors.append("'Size' must be a positive integer")
 
     if errors:

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -12,8 +12,69 @@ from EventManager import EventManager
 data_lock = threading.Lock()
 
 
-with open('config.json', 'r') as f:
+REQUIRED_CONFIG_SCHEMA = {
+    "Target": str,
+    "NoOfProbes": int,
+    "From": list,
+    "Measure": str,
+    "Me": str,
+    "Packets": int,
+    "Size": int,
+}
+
+
+def validate_config(config):
+    """
+    Validates config.json against the fields MeasurementsClient actually
+    needs. Collects every problem found instead of stopping at the first
+    one, so a contributor setting up config.json for the first time can
+    fix everything in a single pass rather than one confusing KeyError
+    at a time.
+    """
+    errors = []
+
+    for key, expected_type in REQUIRED_CONFIG_SCHEMA.items():
+        if key not in config:
+            errors.append(f"Missing required key: '{key}'")
+            continue
+        if not isinstance(config[key], expected_type):
+            errors.append(
+                f"'{key}' should be of type {expected_type.__name__}, "
+                f"got {type(config[key]).__name__}"
+            )
+
+    # Value-level checks, only run if the type checks above already passed
+    # for that field (no point checking .strip() on something that isn't
+    # a string, for example).
+    if isinstance(config.get("Target"), str) and not config["Target"].strip():
+        errors.append("'Target' cannot be an empty string")
+
+    if isinstance(config.get("From"), list):
+        if len(config["From"]) == 0:
+            errors.append("'From' cannot be an empty list")
+        elif not all(isinstance(c, str) and len(c) == 2 for c in config["From"]):
+            errors.append("'From' must be a list of 2-letter country codes (e.g. 'US', 'IN')")
+
+    if isinstance(config.get("NoOfProbes"), int) and config["NoOfProbes"] <= 0:
+        errors.append("'NoOfProbes' must be a positive integer")
+
+    if isinstance(config.get("Packets"), int) and config["Packets"] <= 0:
+        errors.append("'Packets' must be a positive integer")
+
+    if isinstance(config.get("Size"), int) and config["Size"] <= 0:
+        errors.append("'Size' must be a positive integer")
+
+    if errors:
+        error_message = "Invalid config.json:\n  - " + "\n  - ".join(errors)
+        raise ValueError(error_message)
+
+
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
+
+with open(CONFIG_PATH, 'r') as f:
     config = json.load(f)
+
+validate_config(config)
 
 #Get the constants for the RIPE Atlas Measurements from config.json.
 target = config['Target']
@@ -168,12 +229,18 @@ def update_json():
 def run_threaded(job_func):
     job_thread = threading.Thread(target=job_func)
     job_thread.start()
-    
-# The thread scheduling
-schedule.every(1).minutes.do(run_threaded, measure_latency)
-schedule.every(2).minutes.do(run_threaded, update_json)
 
-# Keep running in a loop.
-while True:
-    schedule.run_pending()
-    time.sleep(1)
+
+def main():
+    # The thread scheduling
+    schedule.every(1).minutes.do(run_threaded, measure_latency)
+    schedule.every(2).minutes.do(run_threaded, update_json)
+
+    # Keep running in a loop.
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/measurements_client/MeasurementsClient.py
+++ b/modules/measurements_client/MeasurementsClient.py
@@ -37,10 +37,11 @@ def validate_config(config):
         if key not in config:
             errors.append(f"Missing required key: '{key}'")
             continue
-        if not isinstance(config[key], expected_type):
+        val = config[key]
+        if not isinstance(val, expected_type) or (expected_type is int and isinstance(val, bool)):
             errors.append(
                 f"'{key}' should be of type {expected_type.__name__}, "
-                f"got {type(config[key]).__name__}"
+                f"got {type(val).__name__}"
             )
 
     # Value-level checks, only run if the type checks above already passed

--- a/tests/test_measurements_client_config.py
+++ b/tests/test_measurements_client_config.py
@@ -1,0 +1,78 @@
+import unittest
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'modules', 'measurements_client')))
+from MeasurementsClient import validate_config
+
+
+VALID_CONFIG = {
+    "Target": "99.79.30.74",
+    "NoOfProbes": 500,
+    "From": ["US", "IN", "GB"],
+    "Measure": "ping",
+    "Me": "2600:1700:c710:4f10:1:f7ff:fece:8b21",
+    "Packets": 1,
+    "Size": 2048,
+}
+
+
+class TestValidateConfig(unittest.TestCase):
+    def test_valid_config_passes(self):
+        # Should not raise
+        validate_config(dict(VALID_CONFIG))
+
+    def test_missing_key_raises(self):
+        config = dict(VALID_CONFIG)
+        del config["Target"]
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("Missing required key: 'Target'", str(ctx.exception))
+
+    def test_wrong_type_raises(self):
+        config = dict(VALID_CONFIG)
+        config["NoOfProbes"] = "500"  # should be int, not str
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("'NoOfProbes' should be of type int", str(ctx.exception))
+
+    def test_empty_target_raises(self):
+        config = dict(VALID_CONFIG)
+        config["Target"] = "   "
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("'Target' cannot be an empty string", str(ctx.exception))
+
+    def test_empty_from_list_raises(self):
+        config = dict(VALID_CONFIG)
+        config["From"] = []
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("'From' cannot be an empty list", str(ctx.exception))
+
+    def test_invalid_country_code_raises(self):
+        config = dict(VALID_CONFIG)
+        config["From"] = ["USA"]  # 3 letters, not 2
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("2-letter country codes", str(ctx.exception))
+
+    def test_negative_no_of_probes_raises(self):
+        config = dict(VALID_CONFIG)
+        config["NoOfProbes"] = -5
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        self.assertIn("'NoOfProbes' must be a positive integer", str(ctx.exception))
+
+    def test_multiple_errors_collected_together(self):
+        config = {"Target": "", "NoOfProbes": -1}
+        with self.assertRaises(ValueError) as ctx:
+            validate_config(config)
+        message = str(ctx.exception)
+        self.assertIn("Missing required key: 'From'", message)
+        self.assertIn("Missing required key: 'Measure'", message)
+        self.assertIn("'NoOfProbes' must be a positive integer", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MeasurementsClient previously loaded config.json and directly indexed 
required keys like config['Target'] with no validation. A missing key, 
wrong type, or invalid value anywhere in the file would crash with a raw 
KeyError that gave no indication of what was actually wrong or how to fix 
it, which is a rough experience for anyone setting up their own config.json 
for the first time.

This PR adds a validate_config function that checks all required keys are 
present, have the correct type, and satisfy basic sanity constraints (non-
empty target, positive probe/packet/size counts, a non-empty list of valid 
2-letter country codes for From). Rather than stopping at the first problem 
found, it collects every issue and raises a single clear error message 
listing all of them at once.

While adding tests for this, two pre-existing issues surfaced. First, 
MeasurementsClient.py ran its scheduling loop immediately at import time, 
which meant importing the module for testing purposes would hang 
indefinitely; this has been moved into a main() function guarded by 
if __name__ == "__main__", matching the same fix applied in a previous PR 
to this file. Second, config.json was loaded using a plain relative path, 
which only resolved correctly if the script happened to be run with 
modules/measurements_client as the current working directory; this now 
resolves the path relative to the script's own location, so it works 
regardless of where it's invoked from (including from CI, which runs 
pytest from the repository root).

Verified with a new test file, tests/test_measurements_client_config.py, 
covering valid configs, missing keys, wrong types, empty/invalid values, 
and multiple simultaneous errors being reported together. All 8 tests pass.