### PR TITLE
Add pytest.ini and conftest.py for consistent test discovery

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/modules/emulator/src/routing/test_latency_relaxing.py
+++ b/modules/emulator/src/routing/test_latency_relaxing.py
@@ -6,7 +6,7 @@ import os
 # Add the root directory to sys.path to allow imports from modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
 
-from modules.emulator.src.routing.latency_relaxing import LatencyRelaxing
+from modules.cloud_router.src.routing.latency_relaxing import LatencyRelaxing
 from modules.emulator.src.trace_manager.Measurement import Measurement
 from modules.emulator.src.utils.constants import MininetConstants
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests modules
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra


### PR DESCRIPTION
Test files in this project have repeatedly needed ad-hoc fixes for the same 
underlying problem: imports and file paths only resolving correctly when 
pytest happened to be run from one specific directory. This has come up 
multiple times already, including a missing tests/__init__.py blocking 
module-style test invocation, and MeasurementsClient loading config.json 
via a plain relative path that only worked from its own directory.

This PR adds a conftest.py at the repository root that inserts the project 
root onto sys.path once, centrally, so absolute imports like 
`from modules.emulator.src...` resolve correctly regardless of which 
directory or test file pytest is invoked from. It also adds a pytest.ini 
declaring the project's test file/class/function naming conventions and 
default test paths, matching what the CI workflow already runs.

While verifying this, a real pre-existing bug surfaced again: 
modules/emulator/src/routing/test_latency_relaxing.py still imports 
LatencyRelaxing from modules.emulator.src.routing, but the class actually 
lives under modules.cloud_router.src.routing. This was already fixed in a 
previous PR, but that fix has not yet been merged into main, so it has been 
re-applied here as well to keep this branch's test suite passing 
independently.

Verified by running the full suite from the repository root (9 passed), and 
by running an individual test file via an absolute path from a completely 
different working directory (modules/measurements_client), confirming 
imports resolve correctly either way.