### PR TITLE
Add connection parameter validation to EventManager

### DIFF
--- a/modules/event_manager/EventManager.py
+++ b/modules/event_manager/EventManager.py
@@ -26,11 +26,35 @@ class EventManager:
     to an ActiveMQ broker using the STOMP protocol.
     """
     def __init__(self, host='localhost', port=61613, destination='/queue/awanta.events'):
+        self._validate_connection_params(host, port, destination)
         self.host = host
         self.port = port
         self.destination = destination
         self.conn = None
         self.logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def _validate_connection_params(host, port, destination):
+        """
+        Validates connection parameters up front, so a misconfigured host,
+        port, or destination fails immediately with a clear message instead
+        of surfacing later as an opaque error from deep inside the stomp
+        library.
+        """
+        errors = []
+
+        if not isinstance(host, str) or not host.strip():
+            errors.append("'host' must be a non-empty string")
+
+        if not isinstance(port, int) or isinstance(port, bool) or not (1 <= port <= 65535):
+            errors.append("'port' must be an integer between 1 and 65535")
+
+        if not isinstance(destination, str) or not destination.strip():
+            errors.append("'destination' must be a non-empty string")
+
+        if errors:
+            error_message = "Invalid EventManager connection parameters:\n  - " + "\n  - ".join(errors)
+            raise ValueError(error_message)
 
     def _connect(self):
         """Internal method to establish connection to the broker."""

--- a/tests/test_event_manager_validation.py
+++ b/tests/test_event_manager_validation.py
@@ -1,0 +1,65 @@
+import sys
+import os
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'modules', 'event_manager')))
+
+from EventManager import EventManager
+
+
+class TestEventManagerValidation(unittest.TestCase):
+    def test_valid_defaults_do_not_raise(self):
+        # Should not raise
+        EventManager()
+
+    def test_valid_custom_params_do_not_raise(self):
+        # Should not raise
+        EventManager(host='broker.example.com', port=61614, destination='/queue/custom')
+
+    def test_empty_host_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(host='   ')
+        self.assertIn("'host' must be a non-empty string", str(ctx.exception))
+
+    def test_non_string_host_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(host=None)
+        self.assertIn("'host' must be a non-empty string", str(ctx.exception))
+
+    def test_non_integer_port_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(port="61613")
+        self.assertIn("'port' must be an integer between 1 and 65535", str(ctx.exception))
+
+    def test_out_of_range_port_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(port=70000)
+        self.assertIn("'port' must be an integer between 1 and 65535", str(ctx.exception))
+
+    def test_zero_port_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(port=0)
+        self.assertIn("'port' must be an integer between 1 and 65535", str(ctx.exception))
+
+    def test_boolean_port_raises(self):
+        # bool is technically an int subclass in Python; must not be accepted as a valid port
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(port=True)
+        self.assertIn("'port' must be an integer between 1 and 65535", str(ctx.exception))
+
+    def test_empty_destination_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(destination='')
+        self.assertIn("'destination' must be a non-empty string", str(ctx.exception))
+
+    def test_multiple_invalid_params_collected_together(self):
+        with self.assertRaises(ValueError) as ctx:
+            EventManager(host='', port=-1, destination='')
+        message = str(ctx.exception)
+        self.assertIn("'host' must be a non-empty string", message)
+        self.assertIn("'port' must be an integer between 1 and 65535", message)
+        self.assertIn("'destination' must be a non-empty string", message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EventManager's constructor accepted host, port, and destination with no 
validation, so an invalid value (a non-string host, an out-of-range or 
non-integer port, an empty destination) would be silently stored and only 
surface later as an opaque error from deep inside the stomp library, rather 
than a clear message pointing at the actual misconfiguration.

This PR adds a _validate_connection_params static method, called from 
__init__, that checks all three parameters up front and collects every 
problem found into a single, clear ValueError rather than failing on just 
the first one. This follows the same validation pattern used in a previous 
PR for MeasurementsClient's config.json loading.

Verified with a new test file, tests/test_event_manager_validation.py, 
covering valid defaults, valid custom parameters, and each invalid case 
individually (empty/non-string host, non-integer/out-of-range/boolean port, 
empty destination), plus a test confirming multiple simultaneous errors are 
reported together. All 10 new tests pass, and the existing EventManager 
test suite (2 tests) continues to pass unmodified.