### PR TITLE
Add run_awanta.sh to orchestrate controller and topology startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ First, ensure your virtual environment is set up and all requirements are instal
    source .venv/bin/activate
    ryu-manager --observe-links modules/emulator/controller.py
    ```
+### One-command run
+
+Alternatively, once `./setup_env.sh` has been run, you can start both the 
+controller and the Mininet topology together, with automatic cleanup on exit:
+
+```bash
+./run_awanta.sh -topo full_mesh_topology -trace custom_latency_extractor -routing latency_relaxing
+```
+
+All three flags are optional and default to the values shown above. Exiting 
+the Mininet CLI (type `exit`) will automatically stop the Ryu controller and 
+clean up Mininet state.
 
 # Citing AWANTA
 

--- a/run_awanta.sh
+++ b/run_awanta.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# run_awanta.sh - Orchestrates a full AWANTA run: starts the Ryu controller
+# in the background, then launches the Mininet topology in the foreground
+# (which needs sudo and gives you the interactive Mininet CLI). On exit,
+# automatically tears down the controller and cleans up leftover Mininet
+# state, so you don't have to manage two terminals and remember cleanup
+# by hand every time.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PYTHON="$SCRIPT_DIR/.venv/bin/python"
+CONTROLLER_LOG="$SCRIPT_DIR/controller.log"
+
+TOPOLOGY="full_mesh_topology"
+TRACE_MANAGER="custom_latency_extractor"
+ROUTING="latency_relaxing"
+
+usage() {
+    echo "Usage: ./run_awanta.sh [-topo TOPOLOGY] [-trace TRACE_MANAGER] [-routing ROUTING]"
+    echo ""
+    echo "  -topo     Topology class to run (default: full_mesh_topology)"
+    echo "  -trace    Trace manager strategy: custom_latency_extractor | event_trace_manager (default: custom_latency_extractor)"
+    echo "  -routing  Routing strategy (default: latency_relaxing)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -topo) TOPOLOGY="$2"; shift 2 ;;
+        -trace) TRACE_MANAGER="$2"; shift 2 ;;
+        -routing) ROUTING="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown argument: $1"; usage ;;
+    esac
+done
+
+if [ ! -x "$VENV_PYTHON" ]; then
+    echo "Error: virtual environment not found at $SCRIPT_DIR/.venv"
+    echo "Run ./setup_env.sh first."
+    exit 1
+fi
+
+CONTROLLER_PID=""
+
+cleanup() {
+    echo ""
+    echo "Shutting down AWANTA..."
+    if [ -n "$CONTROLLER_PID" ] && kill -0 "$CONTROLLER_PID" 2>/dev/null; then
+        echo "  Stopping Ryu controller (PID $CONTROLLER_PID)..."
+        kill "$CONTROLLER_PID" 2>/dev/null || true
+        wait "$CONTROLLER_PID" 2>/dev/null || true
+    fi
+    echo "  Cleaning up Mininet state..."
+    sudo mn -c > /dev/null 2>&1 || true
+    echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+echo "Cleaning up any leftover Mininet state from a previous run..."
+sudo mn -c > /dev/null 2>&1 || true
+
+echo "Starting Ryu controller (trace_manager=$TRACE_MANAGER, routing=$ROUTING)..."
+echo "  Logs: $CONTROLLER_LOG"
+"$SCRIPT_DIR/.venv/bin/ryu-manager" --observe-links \
+    --trace_manager="$TRACE_MANAGER" --routing="$ROUTING" \
+    "$SCRIPT_DIR/modules/emulator/controller.py" > "$CONTROLLER_LOG" 2>&1 &
+CONTROLLER_PID=$!
+
+sleep 2
+if ! kill -0 "$CONTROLLER_PID" 2>/dev/null; then
+    echo "Error: Ryu controller failed to start. Check $CONTROLLER_LOG for details."
+    exit 1
+fi
+echo "  Controller running (PID $CONTROLLER_PID)"
+
+echo "Starting Mininet topology '$TOPOLOGY' (requires sudo)..."
+echo "  Type 'exit' in the Mininet CLI when you're done to shut everything down cleanly."
+echo ""
+sudo "$VENV_PYTHON" "$SCRIPT_DIR/modules/emulator/run_topology.py" -topo "$TOPOLOGY"


### PR DESCRIPTION
Running AWANTA currently requires manually coordinating two separate 
terminals: one running the Mininet topology with sudo (which blocks in an 
interactive CLI), and another running the Ryu controller. There's also no 
built-in cleanup step, so leftover Mininet network state from a previous 
run can silently break the next one if `mn -c` isn't run manually first.

This PR adds run_awanta.sh, a single entry point that starts the Ryu 
controller in the background (logging its output to controller.log), waits 
for it to come up, then launches the Mininet topology in the foreground so 
you still get the interactive Mininet CLI. On exit, whether from typing 
`exit` in the CLI or Ctrl+C, it automatically stops the controller process 
and cleans up Mininet state, so there's nothing left to remember or clean 
up by hand.

The script accepts optional -topo, -trace, and -routing flags matching the 
options already supported by controller.py and run_topology.py, and prints 
a clear error if setup_env.sh hasn't been run yet (no virtual environment 
found) rather than failing partway through.

The README's "Running AWANTA" section has been updated with a short 
"One-command run" subsection pointing to this script, alongside the 
existing manual two-terminal instructions which remain valid.

Verified: the script's syntax is valid, --help prints usage correctly, and 
the "missing virtual environment" error path was tested directly by running 
the script from a directory with no .venv present. The full startup path 
(spawning ryu-manager and Mininet together) requires sudo and creates real 
virtual network interfaces, so it should be run and confirmed directly by a 
reviewer or maintainer outside of this development session.