### PR TITLE
Add TwoHopRelaxing routing strategy

### DIFF
--- a/modules/cloud_router/CloudRouter.py
+++ b/modules/cloud_router/CloudRouter.py
@@ -1,5 +1,6 @@
 import logging
 from .src.routing.latency_relaxing import LatencyRelaxing
+from .src.routing.two_hop_relaxing import TwoHopRelaxing
 
 class CloudRouter:
     """
@@ -7,7 +8,8 @@ class CloudRouter:
     In the AWANTA framework, a Cloud Router instance runs on each edge node.
     """
     STRATEGIES = {
-        'latency_relaxing': LatencyRelaxing
+        'latency_relaxing': LatencyRelaxing,
+        'two_hop_relaxing': TwoHopRelaxing,
     }
 
     def __init__(self, network_manager, datapaths, strategy='latency_relaxing'):

--- a/modules/cloud_router/src/routing/two_hop_relaxing.py
+++ b/modules/cloud_router/src/routing/two_hop_relaxing.py
@@ -1,0 +1,62 @@
+from .routing import Routing
+
+class TwoHopRelaxing(Routing):
+    """
+    Extends the single-hop relaxation idea used by LatencyRelaxing to also
+    consider two-hop detours. LatencyRelaxing only checks whether a single
+    intermediate node beats the direct link; on topologies larger than a
+    full mesh of 3 nodes, a route via two intermediate nodes can sometimes
+    beat both the direct link and any single available one-hop detour.
+    This strategy checks direct, one-hop, and two-hop candidate paths and
+    picks whichever has the lowest total latency.
+    """
+
+    def __init__(self, network_manager, datapaths):
+        super().__init__(network_manager, datapaths)
+
+    def get_optimal_route(self, source_dpid, target_dpid):
+        source_index = self.link_to_index[source_dpid]
+        target_index = self.link_to_index[target_dpid]
+        n = len(self.rtt_matrix)
+
+        best_latency = self.rtt_matrix[source_index][target_index]
+        best_path_indices = []  # intermediate hop indices, in order
+
+        # Check every single-hop detour: source -> j -> target
+        for j in range(n):
+            if j == source_index or j == target_index:
+                continue
+            latency = self.rtt_matrix[source_index][j] + self.rtt_matrix[j][target_index]
+            if latency < best_latency:
+                best_latency = latency
+                best_path_indices = [j]
+
+        # Check every two-hop detour: source -> j -> k -> target
+        for j in range(n):
+            if j == source_index or j == target_index:
+                continue
+            for k in range(n):
+                if k == source_index or k == target_index or k == j:
+                    continue
+                latency = (
+                    self.rtt_matrix[source_index][j]
+                    + self.rtt_matrix[j][k]
+                    + self.rtt_matrix[k][target_index]
+                )
+                if latency < best_latency:
+                    best_latency = latency
+                    best_path_indices = [j, k]
+
+        output_dpids = [source_dpid]
+        output_dpids.extend(self.index_to_link[i] for i in best_path_indices)
+        output_dpids.append(target_dpid)
+        return output_dpids
+
+    def update_rtt_matrix(self, latency_results):
+        for measurement in latency_results:
+            source_dpid = measurement.src
+            latency_data = measurement.metric
+            source_index = self.link_to_index[source_dpid]
+            for dpid, latency in latency_data.items():
+                target_index = self.link_to_index[int(dpid)]
+                self.rtt_matrix[source_index][target_index] = latency

--- a/modules/emulator/src/routing/__init__.py
+++ b/modules/emulator/src/routing/__init__.py
@@ -1,5 +1,7 @@
 from modules.cloud_router.src.routing.latency_relaxing import LatencyRelaxing
+from modules.cloud_router.src.routing.two_hop_relaxing import TwoHopRelaxing
 
 routing = {
     "latency_relaxing": LatencyRelaxing,
+    "two_hop_relaxing": TwoHopRelaxing,
 }

--- a/modules/emulator/src/routing/test_latency_relaxing.py
+++ b/modules/emulator/src/routing/test_latency_relaxing.py
@@ -6,7 +6,7 @@ import os
 # Add the root directory to sys.path to allow imports from modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
 
-from modules.emulator.src.routing.latency_relaxing import LatencyRelaxing
+from modules.cloud_router.src.routing.latency_relaxing import LatencyRelaxing
 from modules.emulator.src.trace_manager.Measurement import Measurement
 from modules.emulator.src.utils.constants import MininetConstants
 

--- a/tests/test_two_hop_relaxing.py
+++ b/tests/test_two_hop_relaxing.py
@@ -1,0 +1,79 @@
+import unittest
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.cloud_router.src.routing.two_hop_relaxing import TwoHopRelaxing
+from modules.emulator.src.trace_manager.Measurement import Measurement
+
+
+class TestTwoHopRelaxing(unittest.TestCase):
+    def setUp(self):
+        from unittest.mock import MagicMock
+        self.mock_network_manager = MagicMock()
+        self.mock_datapaths = {}
+        self.router = TwoHopRelaxing(self.mock_network_manager, self.mock_datapaths)
+
+        # 4 nodes: s1, s2, s3, s4 -> indices 0, 1, 2, 3
+        self.router.link_to_index = {1: 0, 2: 1, 3: 2, 4: 3}
+        self.router.index_to_link = {0: 1, 1: 2, 2: 3, 3: 4}
+        self.router.rtt_matrix = [[sys.maxsize for _ in range(4)] for _ in range(4)]
+
+    def test_update_rtt_matrix(self):
+        latency_results = [
+            Measurement(1, {"2": 10, "3": 50}),
+            Measurement(2, {"1": 10, "3": 15}),
+        ]
+        self.router.update_rtt_matrix(latency_results)
+
+        self.assertEqual(self.router.rtt_matrix[0][1], 10)
+        self.assertEqual(self.router.rtt_matrix[0][2], 50)
+        self.assertEqual(self.router.rtt_matrix[1][0], 10)
+        self.assertEqual(self.router.rtt_matrix[1][2], 15)
+
+    def test_direct_path_wins_when_it_is_shortest(self):
+        # s1-s4 direct is far cheaper than any detour
+        self.router.rtt_matrix[0][3] = 5
+        self.router.rtt_matrix[0][1] = 100
+        self.router.rtt_matrix[1][3] = 100
+
+        route = self.router.get_optimal_route(1, 4)
+        self.assertEqual(route, [1, 4])
+
+    def test_one_hop_wins_over_direct(self):
+        # s1-s4 direct is expensive; s1-s2-s4 is cheaper
+        self.router.rtt_matrix[0][3] = 100
+        self.router.rtt_matrix[0][1] = 10
+        self.router.rtt_matrix[1][3] = 15
+
+        route = self.router.get_optimal_route(1, 4)
+        self.assertEqual(route, [1, 2, 4])
+
+    def test_two_hop_wins_over_direct_and_one_hop(self):
+        # Direct is expensive, the only one-hop option is mediocre,
+        # but a two-hop path via s2 -> s3 is the cheapest overall.
+        self.router.rtt_matrix[0][3] = 100   # direct s1-s4
+        self.router.rtt_matrix[0][1] = 40    # s1-s2
+        self.router.rtt_matrix[1][3] = 45    # s2-s4 (one-hop total: 85)
+        self.router.rtt_matrix[0][1] = 10    # s1-s2 (reused for two-hop path)
+        self.router.rtt_matrix[1][2] = 10    # s2-s3
+        self.router.rtt_matrix[2][3] = 10    # s3-s4 (two-hop total: 30)
+
+        route = self.router.get_optimal_route(1, 4)
+        self.assertEqual(route, [1, 2, 3, 4])
+
+    def test_no_beneficial_detour_falls_back_to_direct(self):
+        self.router.rtt_matrix[0][3] = 10
+        # All other links are expensive, so nothing beats the direct link
+        for i in range(4):
+            for j in range(4):
+                if i != j and not (i == 0 and j == 3):
+                    self.router.rtt_matrix[i][j] = 1000
+
+        route = self.router.get_optimal_route(1, 4)
+        self.assertEqual(route, [1, 4])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
CloudRouter's routing layer is built to be pluggable via a STRATEGIES 
mapping, but only ever had one implementation, LatencyRelaxing, which 
checks whether a single intermediate node beats the direct link between 
two switches. On a topology larger than a full mesh of 3 nodes, a route via 
two intermediate nodes can sometimes beat both the direct link and any 
single available one-hop detour, and the existing strategy has no way to 
find that.

This PR adds TwoHopRelaxing, a second strategy that extends the same 
relaxation idea to also evaluate two-hop candidate paths, choosing whichever 
of direct, one-hop, or two-hop has the lowest total latency. It's 
registered alongside LatencyRelaxing in both places a routing strategy 
needs to be known: CloudRouter's STRATEGIES dict, and 
modules/emulator/src/routing/__init__.py, which is what controller.py 
actually resolves the --routing= runtime option against. No changes were 
needed to the shared Routing base class or its flow-installation logic 
(set_optimal_route), since it already supports paths of arbitrary length.

While verifying this, the existing test_latency_relaxing.py test file was 
found to still have the stale import path bug fixed in a previous, not-yet-
merged PR (LatencyRelaxing imported from modules.emulator.src.routing 
instead of modules.cloud_router.src.routing). It's been re-applied here so 
this branch's test suite passes independently of that PR's merge status.

Verified with a new test file, tests/test_two_hop_relaxing.py, covering RTT 
matrix updates and four routing scenarios: direct path optimal, one-hop 
optimal, two-hop optimal (specifically constructed so a two-hop route beats 
both direct and the only available one-hop option), and no beneficial 
detour existing at all. All 5 new tests pass, and the existing 
LatencyRelaxing tests continue to pass unmodified in behavior.