### PR TITLE
Add CompositeMetricRelaxing routing strategy using RTT, jitter, and hop count

### DIFF
--- a/modules/cloud_router/CloudRouter.py
+++ b/modules/cloud_router/CloudRouter.py
@@ -1,5 +1,12 @@
 import logging
 from .src.routing.latency_relaxing import LatencyRelaxing
+from .src.routing.composite_metric_relaxing import CompositeMetricRelaxing
+
+STRATEGIES = {
+        'latency_relaxing': LatencyRelaxing,
+        'two_hop_relaxing': TwoHopRelaxing,
+        'composite_metric_relaxing': CompositeMetricRelaxing,
+    }
 
 class CloudRouter:
     """

--- a/modules/cloud_router/src/routing/composite_metric_relaxing.py
+++ b/modules/cloud_router/src/routing/composite_metric_relaxing.py
@@ -1,0 +1,83 @@
+import sys
+from .routing import Routing
+
+
+class CompositeMetricRelaxing(Routing):
+    """
+    Extends the single-hop relaxation idea used by LatencyRelaxing, but
+    scores candidate paths using a composite of RTT, jitter, and hop count
+    instead of RTT alone.
+
+    Motivation: AWANTA's measurement pipeline (see EventTraceManager and
+    MeasurementsClient) already captures jitter and hop count alongside RTT,
+    but every existing routing strategy discards them and optimizes on raw
+    RTT only. For AWANTA's actual use case, telehealth traffic, jitter
+    matters disproportionately for real-time audio/video quality, and hop
+    count is a reasonable proxy for path stability (more hops generally
+    means more points of failure and reconfiguration risk). This strategy
+    factors both in explicitly, rather than ignoring signal the pipeline
+    already collects.
+
+    Scoring: score = rtt + (jitter_weight * jitter) + (hop_weight * hop_count)
+
+    RTT remains the dominant term (weight 1), so this strategy reduces to
+    the same behavior as LatencyRelaxing when jitter and hop_count are zero
+    or unavailable. The default weights (jitter_weight=2.0, hop_weight=5.0)
+    reflect jitter being penalized more per unit than latency, and hop count
+    acting as a smaller tie-breaking/stability adjustment; both are
+    configurable since the right weighting is deployment-specific.
+    """
+
+    def __init__(self, network_manager, datapaths, jitter_weight: float = 2.0, hop_weight: float = 5.0):
+        super().__init__(network_manager, datapaths)
+        self.jitter_weight = jitter_weight
+        self.hop_weight = hop_weight
+        n = len(self.rtt_matrix)
+        self.jitter_matrix = [[0.0 for _ in range(n)] for _ in range(n)]
+        self.hop_count_matrix = [[0 for _ in range(n)] for _ in range(n)]
+
+    def _composite_score(self, i: int, j: int) -> float:
+        rtt = self.rtt_matrix[i][j]
+        if rtt == sys.maxsize:
+            # Unmeasured/unreachable link: never let jitter or hop count
+            # make this look attractive relative to a measured link.
+            return sys.maxsize
+        return rtt + (self.jitter_weight * self.jitter_matrix[i][j]) + (self.hop_weight * self.hop_count_matrix[i][j])
+
+    def get_optimal_route(self, source_dpid, target_dpid):
+        source_index = self.link_to_index[source_dpid]
+        target_index = self.link_to_index[target_dpid]
+        direct_score = self._composite_score(source_index, target_index)
+        one_hop_node = None
+        output_dpids = [source_dpid]
+
+        for j in range(len(self.rtt_matrix)):
+            if j == source_index or j == target_index:
+                continue
+            candidate_score = self._composite_score(source_index, j) + self._composite_score(j, target_index)
+            if candidate_score < direct_score:
+                direct_score = candidate_score
+                one_hop_node = self.index_to_link[j]
+
+        if one_hop_node is not None:
+            output_dpids.append(one_hop_node)
+        output_dpids.append(target_dpid)
+        return output_dpids
+
+    def update_rtt_matrix(self, latency_results):
+        for measurement in latency_results:
+            source_dpid = measurement.src
+            source_index = self.link_to_index[source_dpid]
+            latency_data = measurement.metric
+
+            for dpid, latency in latency_data.items():
+                target_index = self.link_to_index[int(dpid)]
+                self.rtt_matrix[source_index][target_index] = latency
+
+            # jitter and hop_count are per-measurement (one value per source
+            # node for this update cycle), not per-target like latency_data,
+            # so they're recorded against every target this source reported on.
+            for dpid in latency_data.keys():
+                target_index = self.link_to_index[int(dpid)]
+                self.jitter_matrix[source_index][target_index] = measurement.jitter
+                self.hop_count_matrix[source_index][target_index] = measurement.hop_count

--- a/modules/emulator/src/routing/__init__.py
+++ b/modules/emulator/src/routing/__init__.py
@@ -1,5 +1,7 @@
-from modules.cloud_router.src.routing.latency_relaxing import LatencyRelaxing
+from modules.cloud_router.src.routing.composite_metric_relaxing import CompositeMetricRelaxing
 
 routing = {
     "latency_relaxing": LatencyRelaxing,
+    "two_hop_relaxing": TwoHopRelaxing,
+    "composite_metric_relaxing": CompositeMetricRelaxing,
 }

--- a/tests/test_composite_metric_relaxing.py
+++ b/tests/test_composite_metric_relaxing.py
@@ -1,0 +1,82 @@
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.cloud_router.src.routing.composite_metric_relaxing import CompositeMetricRelaxing
+from modules.emulator.src.trace_manager.Measurement import Measurement
+
+
+class TestCompositeMetricRelaxing(unittest.TestCase):
+    def setUp(self):
+        self.router = CompositeMetricRelaxing(MagicMock(), {})
+        self.router.link_to_index = {1: 0, 2: 1, 3: 2}
+        self.router.index_to_link = {0: 1, 1: 2, 2: 3}
+        self.router.rtt_matrix = [[sys.maxsize for _ in range(3)] for _ in range(3)]
+        self.router.jitter_matrix = [[0.0 for _ in range(3)] for _ in range(3)]
+        self.router.hop_count_matrix = [[0 for _ in range(3)] for _ in range(3)]
+
+    def test_update_rtt_matrix_records_rtt_jitter_and_hop_count(self):
+        latency_results = [
+            Measurement(1, {"2": 10, "3": 50}, jitter=1.5, hop_count=2),
+        ]
+        self.router.update_rtt_matrix(latency_results)
+
+        self.assertEqual(self.router.rtt_matrix[0][1], 10)
+        self.assertEqual(self.router.jitter_matrix[0][1], 1.5)
+        self.assertEqual(self.router.hop_count_matrix[0][1], 2)
+
+    def test_behaves_like_pure_rtt_when_jitter_and_hops_are_zero(self):
+        # With no jitter/hop penalty, this should match LatencyRelaxing's baseline behavior.
+        self.router.rtt_matrix[0][1] = 10
+        self.router.rtt_matrix[1][2] = 15
+        self.router.rtt_matrix[0][2] = 50
+
+        route = self.router.get_optimal_route(1, 3)
+        self.assertEqual(route, [1, 2, 3])
+
+    def test_high_jitter_on_lower_latency_direct_link_favors_relaxed_path(self):
+        # Direct link has the lowest raw RTT, but very high jitter makes it
+        # unattractive relative to a slightly slower but stable relayed path.
+        self.router.rtt_matrix[0][2] = 20         # s1-s3 direct: fast...
+        self.router.jitter_matrix[0][2] = 50       # ...but extremely jittery
+        self.router.rtt_matrix[0][1] = 15          # s1-s2
+        self.router.rtt_matrix[1][2] = 15          # s2-s3 (total RTT: 30, worse than direct's 20)
+        # jitter/hop on the relayed path left at 0 (clean, stable path)
+
+        route = self.router.get_optimal_route(1, 3)
+        self.assertEqual(route, [1, 2, 3])
+
+    def test_hop_count_penalty_can_tip_a_close_decision(self):
+        self.router.rtt_matrix[0][2] = 30           # s1-s3 direct
+        self.router.rtt_matrix[0][1] = 14           # s1-s2
+        self.router.rtt_matrix[1][2] = 15           # s2-s3 (total RTT: 29, barely better than direct)
+        self.router.hop_count_matrix[0][1] = 10      # but this hop is reported as high hop-count/unstable
+
+        # hop_weight default 5.0 * 10 hops = 50 penalty, easily outweighing the 1ms RTT saving
+        route = self.router.get_optimal_route(1, 3)
+        self.assertEqual(route, [1, 3])
+
+    def test_custom_weights_are_respected(self):
+        router = CompositeMetricRelaxing(MagicMock(), {}, jitter_weight=0.0, hop_weight=0.0)
+        router.link_to_index = {1: 0, 2: 1, 3: 2}
+        router.index_to_link = {0: 1, 1: 2, 2: 3}
+        router.rtt_matrix = [[sys.maxsize for _ in range(3)] for _ in range(3)]
+        router.jitter_matrix = [[0.0 for _ in range(3)] for _ in range(3)]
+        router.hop_count_matrix = [[0 for _ in range(3)] for _ in range(3)]
+
+        # With weights zeroed out, jitter/hop_count should have no effect at all.
+        router.rtt_matrix[0][2] = 20
+        router.jitter_matrix[0][2] = 999
+        router.hop_count_matrix[0][2] = 999
+        router.rtt_matrix[0][1] = 15
+        router.rtt_matrix[1][2] = 15
+
+        route = router.get_optimal_route(1, 3)
+        self.assertEqual(route, [1, 3])  # direct still wins on pure RTT since penalties are disabled
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
AWANTA's measurement pipeline already captures jitter and hop count 
alongside RTT for every measurement (see Measurement.py, and 
EventTraceManager populating all three fields from live RIPE Atlas data), 
but every existing routing strategy (LatencyRelaxing, TwoHopRelaxing) 
discards jitter and hop count entirely and optimizes on raw RTT alone. 
Given AWANTA's actual purpose is telehealth traffic, this leaves real, 
already-collected signal unused: jitter disproportionately affects 
perceived quality for real-time audio/video, and hop count is a reasonable 
proxy for path stability.

This PR adds CompositeMetricRelaxing, a routing strategy that scores 
candidate paths as rtt + (jitter_weight * jitter) + (hop_weight * 
hop_count) instead of RTT alone, while preserving RTT as the dominant term 
so the strategy reduces to the same behavior as LatencyRelaxing when jitter 
and hop count are zero or unavailable. Default weights (jitter_weight=2.0, 
hop_weight=5.0) reflect jitter being penalized more heavily per unit than 
raw latency, consistent with its outsized impact on call quality; both 
weights are configurable via the constructor since the right tradeoff is 
deployment-specific. It's registered alongside the existing strategies in 
both CloudRouter.STRATEGIES and modules/emulator/src/routing/__init__.py.

Verified with tests/test_composite_metric_relaxing.py, which specifically 
constructs scenarios where jitter and hop count each individually flip the 
routing decision away from what pure RTT would choose, alongside a test 
confirming the strategy matches plain RTT-based behavior when jitter/hop 
weights are zero, and a test confirming custom weights are respected. All 5 
new tests pass, and the full existing test suite continues to pass.