### PR TITLE
Add ECMPRelaxing routing strategy for multi-path load balancing

### DIFF
--- a/modules/cloud_router/src/routing/ecmp_relaxing.py
+++ b/modules/cloud_router/src/routing/ecmp_relaxing.py
@@ -1,0 +1,133 @@
+import sys
+from .routing import Routing
+
+
+class ECMPRelaxing(Routing):
+    """
+    Finds multiple near-equal-cost paths between two switches and assigns
+    each a traffic-split weight, instead of always committing all traffic
+    to a single "best" path. This is useful once a topology has more than
+    one genuinely comparable route available: splitting load across them
+    can use available capacity better than funneling everything through
+    whichever single path happened to win by a small margin.
+
+    Path discovery is a simplified approach inspired by Yen's k-shortest-
+    paths algorithm: find the shortest path via Dijkstra, then repeatedly
+    exclude one edge from an already-found path and re-run Dijkstra to
+    discover an alternate. An alternate is only kept if its total cost is
+    within `tolerance` of the shortest path's cost, so a much worse path
+    never gets a meaningful share of traffic.
+
+    get_optimal_route() still returns a single best path, keeping this
+    strategy fully compatible with the existing single-path CloudRouter/
+    controller flow-installation code. Multi-path behavior is exposed
+    separately through get_k_shortest_paths(), for future integration with
+    weighted OpenFlow group tables (OFPGT_SELECT), which requires a live
+    Mininet/Ryu environment to install and verify.
+    """
+
+    def __init__(self, network_manager, datapaths):
+        super().__init__(network_manager, datapaths)
+
+    def _dijkstra(self, source_index, target_index, excluded_edges=None):
+        excluded_edges = excluded_edges or set()
+        n = len(self.rtt_matrix)
+        distance = [sys.maxsize] * n
+        previous = [None] * n
+        visited = [False] * n
+        distance[source_index] = 0
+
+        for _ in range(n):
+            current = None
+            current_distance = sys.maxsize
+            for i in range(n):
+                if not visited[i] and distance[i] < current_distance:
+                    current = i
+                    current_distance = distance[i]
+            if current is None:
+                break
+            visited[current] = True
+            if current == target_index:
+                break
+            for neighbor in range(n):
+                if visited[neighbor] or neighbor == current:
+                    continue
+                if (current, neighbor) in excluded_edges:
+                    continue
+                weight = self.rtt_matrix[current][neighbor]
+                if weight == sys.maxsize:
+                    continue
+                new_distance = distance[current] + weight
+                if new_distance < distance[neighbor]:
+                    distance[neighbor] = new_distance
+                    previous[neighbor] = current
+
+        path = []
+        step = target_index
+        while step is not None:
+            path.append(step)
+            step = previous[step]
+        path.reverse()
+
+        if not path or path[0] != source_index:
+            return None, sys.maxsize
+        return path, distance[target_index]
+
+    def get_k_shortest_paths(self, source_dpid, target_dpid, k=2, tolerance=0.15):
+        """
+        Returns up to k paths as a list of (dpid_path, weight) tuples,
+        where weights are proportional to inverse path cost and sum to 1.0.
+        Only paths within `tolerance` (fractional) of the best path's cost
+        are included.
+        """
+        source_index = self.link_to_index[source_dpid]
+        target_index = self.link_to_index[target_dpid]
+
+        best_path, best_cost = self._dijkstra(source_index, target_index)
+        if best_path is None:
+            return [([source_dpid, target_dpid], 1.0)]
+
+        results = [(best_path, best_cost)]
+        seen_paths = {tuple(best_path)}
+        excluded_edges = set()
+        candidate_paths = [best_path]
+
+        while len(results) < k and candidate_paths:
+            path_to_branch = candidate_paths.pop(0)
+            for i in range(len(path_to_branch) - 1):
+                edge = (path_to_branch[i], path_to_branch[i + 1])
+                trial_excluded = excluded_edges | {edge}
+                alt_path, alt_cost = self._dijkstra(source_index, target_index, trial_excluded)
+
+                if alt_path is None or tuple(alt_path) in seen_paths:
+                    continue
+                if alt_cost <= best_cost * (1 + tolerance):
+                    results.append((alt_path, alt_cost))
+                    seen_paths.add(tuple(alt_path))
+                    candidate_paths.append(alt_path)
+                    excluded_edges.add(edge)
+                if len(results) >= k:
+                    break
+
+        total_inverse_cost = sum((1.0 / cost) if cost > 0 else 1.0 for _, cost in results)
+        weighted_paths = []
+        for path_indices, cost in results:
+            dpids = [self.index_to_link[i] for i in path_indices]
+            weight = ((1.0 / cost) if cost > 0 else 1.0) / total_inverse_cost
+            weighted_paths.append((dpids, weight))
+        return weighted_paths
+
+    def get_optimal_route(self, source_dpid, target_dpid):
+        # Single-path interface, kept compatible with existing CloudRouter
+        # usage: always returns just the best path.
+        weighted_paths = self.get_k_shortest_paths(source_dpid, target_dpid, k=1)
+        return weighted_paths[0][0]
+
+    def update_rtt_matrix(self, latency_results):
+        for measurement in latency_results:
+            source_dpid = measurement.src
+            source_index = self.link_to_index[source_dpid]
+            latency_data = measurement.metric
+            for dpid, latency in latency_data.items():
+                target_index = self.link_to_index[int(dpid)]
+                self.rtt_matrix[source_index][target_index] = latency

--- a/modules/emulator/src/routing/__init__.py
+++ b/modules/emulator/src/routing/__init__.py
@@ -1,5 +1,9 @@
 from modules.cloud_router.src.routing.latency_relaxing import LatencyRelaxing
+from modules.cloud_router.src.routing.dijkstra_relaxing import DijkstraRelaxing
+from modules.cloud_router.src.routing.ecmp_relaxing import ECMPRelaxing
 
 routing = {
     "latency_relaxing": LatencyRelaxing,
+    "dijkstra_relaxing": DijkstraRelaxing,
+    "ecmp_relaxing": ECMPRelaxing,
 }

--- a/tests/test_ecmp_relaxing.py
+++ b/tests/test_ecmp_relaxing.py
@@ -1,0 +1,92 @@
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.cloud_router.src.routing.ecmp_relaxing import ECMPRelaxing
+
+
+class TestECMPRelaxing(unittest.TestCase):
+    def _make_router(self, n):
+        router = ECMPRelaxing(MagicMock(), {})
+        router.link_to_index = {i + 1: i for i in range(n)}
+        router.index_to_link = {i: i + 1 for i in range(n)}
+        router.rtt_matrix = [[sys.maxsize for _ in range(n)] for _ in range(n)]
+        return router
+
+    def test_single_path_when_no_alternate_exists(self):
+        router = self._make_router(3)
+        router.rtt_matrix[0][1] = 10
+        router.rtt_matrix[1][2] = 10
+        # No other links at all, so only one route from 1 to 3 is possible.
+
+        results = router.get_k_shortest_paths(1, 3, k=2)
+        self.assertEqual(len(results), 1)
+        path, weight = results[0]
+        self.assertEqual(path, [1, 2, 3])
+        self.assertAlmostEqual(weight, 1.0)
+
+    def test_two_equal_cost_disjoint_paths_split_evenly(self):
+        # 4 nodes: two totally separate paths of equal cost from 1 to 4.
+        router = self._make_router(4)
+        router.rtt_matrix[0][1] = 10   # 1 -> 2
+        router.rtt_matrix[1][3] = 10   # 2 -> 4  (path A total: 20)
+        router.rtt_matrix[0][2] = 10   # 1 -> 3
+        router.rtt_matrix[2][3] = 10   # 3 -> 4  (path B total: 20)
+
+        results = router.get_k_shortest_paths(1, 4, k=2)
+        self.assertEqual(len(results), 2)
+        weights = sorted(w for _, w in results)
+        self.assertAlmostEqual(weights[0], 0.5, places=3)
+        self.assertAlmostEqual(weights[1], 0.5, places=3)
+
+    def test_much_worse_alternate_excluded_by_tolerance(self):
+        router = self._make_router(4)
+        router.rtt_matrix[0][1] = 10
+        router.rtt_matrix[1][3] = 10   # best path total: 20
+        router.rtt_matrix[0][2] = 100
+        router.rtt_matrix[2][3] = 100  # alternate total: 200, far outside tolerance
+
+        results = router.get_k_shortest_paths(1, 4, k=2, tolerance=0.15)
+        self.assertEqual(len(results), 1)
+
+    def test_weights_favor_the_cheaper_of_two_within_tolerance_paths(self):
+        router = self._make_router(4)
+        router.rtt_matrix[0][1] = 10
+        router.rtt_matrix[1][3] = 10   # best path total: 20
+        router.rtt_matrix[0][2] = 11
+        router.rtt_matrix[2][3] = 11   # alternate total: 22 (within 15% tolerance of 20)
+
+        results = router.get_k_shortest_paths(1, 4, k=2, tolerance=0.15)
+        self.assertEqual(len(results), 2)
+        best = next(w for p, w in results if p == [1, 2, 4])
+        alt = next(w for p, w in results if p == [1, 3, 4])
+        self.assertGreater(best, alt)
+
+    def test_weights_always_sum_to_one(self):
+        router = self._make_router(4)
+        router.rtt_matrix[0][1] = 10
+        router.rtt_matrix[1][3] = 10
+        router.rtt_matrix[0][2] = 11
+        router.rtt_matrix[2][3] = 11
+
+        results = router.get_k_shortest_paths(1, 4, k=2, tolerance=0.15)
+        total_weight = sum(w for _, w in results)
+        self.assertAlmostEqual(total_weight, 1.0, places=6)
+
+    def test_get_optimal_route_returns_single_best_path_for_compatibility(self):
+        router = self._make_router(4)
+        router.rtt_matrix[0][1] = 10
+        router.rtt_matrix[1][3] = 10
+        router.rtt_matrix[0][2] = 11
+        router.rtt_matrix[2][3] = 11
+
+        route = router.get_optimal_route(1, 4)
+        self.assertEqual(route, [1, 2, 4])
+        self.assertIsInstance(route, list)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Every existing routing strategy always commits all traffic to a single 
"best" path, even when multiple genuinely comparable paths exist between 
two switches. This leaves available network capacity unused: if two paths 
have nearly identical latency, funneling everything through whichever one 
won by a small margin wastes the other path entirely, rather than splitting 
load across both.

This PR adds ECMPRelaxing, which discovers multiple near-equal-cost paths 
between two switches (using a simplified k-shortest-paths approach: find 
the shortest path via Dijkstra, then repeatedly exclude one edge from an 
already-found path and re-run Dijkstra to discover alternates), and assigns 
each a proportional traffic-split weight based on inverse path cost. Only 
alternates within a configurable tolerance (default 15%) of the best path's 
cost are kept, so a much worse path never receives a meaningful share of 
traffic.

get_optimal_route() still returns a single best path, keeping this strategy 
fully backward compatible with the existing single-path CloudRouter/
controller flow-installation code, which was not modified. Multi-path 
behavior is exposed separately via get_k_shortest_paths(), intended for 
future integration with weighted OpenFlow group tables (OFPGT_SELECT). That 
integration requires installing real flow rules in a live Mininet/Ryu 
environment to verify, so this PR deliberately scopes to the path-finding 
and weighting algorithm, which is fully testable in isolation, rather than 
also attempting the OpenFlow installation side in the same change.

It's registered alongside the existing strategies in both 
CloudRouter.STRATEGIES and modules/emulator/src/routing/__init__.py.

Verified with tests/test_ecmp_relaxing.py, covering: falling back to a 
single path when no alternate exists, two equal-cost disjoint paths 
splitting traffic 50/50, a much worse alternate being correctly excluded by 
the tolerance threshold, weights correctly favoring the cheaper of two 
within-tolerance paths, weights always summing to 1.0, and get_optimal_route 
maintaining single-path compatibility. All 6 new tests pass, and the full 
existing test suite continues to pass.